### PR TITLE
Ban Evasion Checker

### DIFF
--- a/code/modules/client/client procs.dm
+++ b/code/modules/client/client procs.dm
@@ -168,6 +168,7 @@ var/next_external_rsc = 0
 
 		if (config.notify_new_player_age >= 0)
 			message_admins("New user: [key_name_admin(src)] is connecting here for the first time.")
+			check_multilog()
 			if (config.irc_first_connection_alert)
 				send2irc_adminless_only("New-user", "[key_name(src)] is connecting for the first time!")
 
@@ -296,6 +297,11 @@ var/next_external_rsc = 0
 	if(config.see_own_notes)
 		verbs += /client/proc/self_notes
 
+/client/proc/check_multilog()
+	if(related_accounts_cid && (related_accounts_cid != "Requires database"))
+		message_admins("<span class='adminnotice'>Multilog Warning: [key_name_admin(src)] CID matches these other ckeys: [related_accounts_cid]</span>")
+	if(related_accounts_ip && (related_accounts_ip != "Requires database"))
+		message_admins("<span class='adminnotice'>Multilog Warning: [key_name_admin(src)] IP matches these other ckeys: [related_accounts_ip]</span>")
 
 #undef TOPIC_SPAM_DELAY
 #undef UPLOAD_LIMIT

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -1,8 +1,8 @@
 /datum/round_event_control/disease_outbreak
 	name = "Disease Outbreak"
 	typepath = /datum/round_event/disease_outbreak
-	max_occurrences = 1
-	weight = 5
+	max_occurrences = 0
+	weight = 0
 
 /datum/round_event/disease_outbreak
 	announceWhen	= 15


### PR DESCRIPTION
Simple proc that checks clients for other clients that have the same CID or IP. Wrote it in like ten seconds but it should save a lot of time for admins. Ripped this from another repo of mine.

Disabled incurable disease outbreaks while I'm at it.